### PR TITLE
Add dep tot he travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ language: go
 go:
   - 1.9.x
 
-script: make
+install:
+  - go get -u github.com/golang/dep/cmd/dep
+
+script:
+  - make


### PR DESCRIPTION
travis will need dep in order to pull dependencies

Signed-off-by: Craig Tracey <craigtracey@gmail.com>